### PR TITLE
chore(scripts): set default PLAN_MODEL to gpt-5-mini

### DIFF
--- a/scripts/ai_plan_issue.py
+++ b/scripts/ai_plan_issue.py
@@ -24,7 +24,7 @@ except Exception:
     Github = None
 
 
-MODEL = os.environ.get("PLAN_MODEL", "gpt-4o-mini")
+MODEL = os.environ.get("PLAN_MODEL", "gpt-5-mini")
 
 SYSTEM_PROMPT = (
     "You are an expert software project planner. Given a GitHub issue, produce a short, actionable plan: "


### PR DESCRIPTION
Set the default PLAN_MODEL used by scripts/ai_plan_issue.py to gpt-5-mini. The script still respects the PLAN_MODEL environment variable and Anthropic fallback remains unchanged.