### PR TITLE
docs: add structured documentation editing rules to assistant instructions

### DIFF
--- a/.github/assistant-guidelines.md
+++ b/.github/assistant-guidelines.md
@@ -116,3 +116,27 @@ How I will reference this
 
 - When you ask me to perform automation, I will follow these rules and (unless you say otherwise) prefer stepwise execution and optional dry-run first.
 - If you prefer a faster single-line approach for any particular step, say so explicitly and I will do it for that step only.
+
+Documentation editing rules (Markdown)
+
+- Scope
+    - Default docs to edit are `README.md` and `PRD.md` unless otherwise requested.
+    - Prefer targeted, section-level changes; do not rewrite entire documents.
+
+- Allowed operations (mirror automation in `scripts/generate_docs.py`)
+    - replace_section(heading, content)
+    - append_to_section(heading, content)
+    - upsert_section(heading, level=2..6, content)
+    - replace_block_by_marker(name, content) using markers `<!-- AUTO-DOC:NAME -->` and `<!-- /AUTO-DOC:NAME -->`
+    - Operate only on unique headings; if ambiguous, skip or create a new section via upsert.
+
+- Constraints and safety checks
+    - Max 6 ops per file in a single update; split larger updates across separate commits/PRs.
+    - Preserve heading text and hierarchy; maintain surrounding blank lines and code-fence integrity.
+    - Don’t reduce a file by >40% in a single change; large deletions need human review.
+    - Keep relative links and anchors stable; update them only when the target actually changed.
+    - Use Windows-friendly PowerShell examples where relevant to this repo; one command per line.
+
+- Review artifacts
+    - Produce a concise unified diff in PRs or logs; surface any warnings like missing markers or non-unique headings.
+    - When applicable, validate against `docs/schema/docs_ops.json` and ensure structured outputs parse cleanly.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -83,3 +83,32 @@ Local dev setup (recommended):
 - Debounce: if the assistant itself posted a `/plan` within the last 2 minutes, do not post again automatically.
 - Single-responsibility: post at most one trigger comment per issue unless explicitly asked to retry; wait for the workflow result and show the maintainer the generated plan before re-triggering.
 - When a skip occurs, post a single informative comment (once) explaining why the trigger was skipped and what the user can do to force a rerun (for example, add a comment `force:/plan` or re-run the workflow).
+
+## Documentation editing rules (README.md, PRD.md)
+
+These rules align with our docs automation (see `scripts/generate_docs.py`) and should be followed for any manual or automated edits to Markdown docs.
+
+- Scope and targets
+  - Default targets are `README.md` and `PRD.md`. Avoid editing other docs unless explicitly requested.
+  - Prefer editing only specific sections or explicit marker blocks; do not rewrite entire files.
+
+- Allowed operations (structured)
+  - Use heading/marker-based ops that mirror automation capabilities:
+    - replace_section(heading, content)
+    - append_to_section(heading, content)
+    - upsert_section(heading, level, content)
+    - replace_block_by_marker(name, content) using markers: `<!-- AUTO-DOC:NAME -->` ... `<!-- /AUTO-DOC:NAME -->`
+  - Operate only on uniquely named headings; if a heading isn’t unique, don’t guess—skip or upsert a new section instead.
+
+- Safety and style constraints
+  - Keep changes minimal and localized; preserve heading text, hierarchy, and surrounding formatting.
+  - Limit to at most 6 operations per file in one pass (be conservative to ease review).
+  - Don’t shrink a file by more than ~40%; large deletions require human review and explicit approval.
+  - Maintain existing tone and style; keep relative links intact; don’t alter anchors unless necessary.
+  - Preserve code fences and languages; for Windows examples, prefer PowerShell syntax and separate commands per line.
+  - Avoid placeholders like “TBD”/“TODO”; prefer concrete, testable statements or omit.
+
+- Validation and parity with automation
+  - When producing machine-readable edits, conform to the JSON schema in `docs/schema/docs_ops.json` and the op types above.
+  - Prefer marker replacements for recurring, auto-managed blocks.
+  - After edits, generate a small unified diff for review; summarize warnings (e.g., skipped ambiguous headings).


### PR DESCRIPTION
This PR adds a documentation editing rules section to both assistant instruction files to align with our generate_docs automation.\n\n- Adds 'Documentation editing rules' to .github/copilot-instructions.md\n- Adds 'Documentation editing rules' to .github/assistant-guidelines.md\n\nThese rules mirror the structured operations supported by scripts/generate_docs.py (replace_section, append_to_section, upsert_section, replace_block_by_marker), include safety constraints (<=6 ops per file, no >40% shrink), and call out schema parity with docs/schema/docs_ops.json.\n\nPlease review and merge if the guidance looks good.