### PR TITLE
feat: add RU/Warsaw mils + faction selection and persistence

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,6 +2,7 @@ export type ComputeRequest = {
   start: [number | string, number | string]
   end: [number | string, number | string]
   precision?: number
+  faction?: 'nato' | 'ru'
 }
 
 export type ComputeResponse = {
@@ -10,6 +11,7 @@ export type ComputeResponse = {
   end: number[]
   distance_m: number
   azimuth_mils: number
+  faction: 'nato' | 'ru'
 }
 
 export async function computeApi(req: ComputeRequest): Promise<ComputeResponse> {

--- a/src/pop_fly/cli.py
+++ b/src/pop_fly/cli.py
@@ -55,7 +55,7 @@ def _load_saved_start() -> tuple[float, float] | None:
     if isinstance(start, list) and len(start) == 2:
         try:
             return (float(start[0]), float(start[1]))
-        except Exception:
+        except (ValueError, TypeError):
             return None
     return None
 

--- a/src/pop_fly/core.py
+++ b/src/pop_fly/core.py
@@ -94,7 +94,7 @@ def compute_distance_bearing_xy(
         mpc = float(mils_per_circle)
     else:
         f = faction.lower()
-        if f in ("nato", "us", "otAN"):
+        if f in ("nato", "us", "otan"):
             mpc = 6400.0
             faction = "nato"
         elif f in ("ru", "russian", "warsaw", "wp"):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,6 +33,16 @@ class TestAPI(unittest.TestCase):
         self.assertEqual(data["azimuth_mils"], 1600.0)
         self.assertNotIn("slant_distance_m", data)
         self.assertNotIn("delta_z_m", data)
+        self.assertEqual(data["faction"], "nato")
+
+    def test_compute_ru_faction(self):
+        payload = {"start": ["00000", "00000"], "end": ["03000", "00000"], "precision": 0, "faction": "ru"}
+        r = self.client.post("/api/compute", json=payload)
+        self.assertEqual(r.status_code, 200)
+        data = r.json()
+        self.assertEqual(data["distance_m"], 3000)
+        self.assertEqual(data["azimuth_mils"], 1500.0)
+        self.assertEqual(data["faction"], "ru")
 
     def test_compute_rejects_three_values(self):
         payload = {"start": ["00000", "00000", 10], "end": ["03000", "00000"], "precision": 0}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -35,11 +35,20 @@ class TestCore(unittest.TestCase):
         self.assertEqual(r.distance_m, 0.0)
         self.assertAlmostEqual(r.azimuth_mils, 0.0, places=6)
 
+    def test_faction_ru_vs_nato(self):
+        # East direction bearing 90 deg should be 1600 NATO, 1500 RU
+        nato = compute_distance_bearing_xy((0,0), (100,0), faction="nato")
+        ru = compute_distance_bearing_xy((0,0), (100,0), faction="ru")
+        self.assertAlmostEqual(nato.azimuth_mils, 1600.0, places=6)
+        self.assertAlmostEqual(ru.azimuth_mils, 1500.0, places=6)
+        self.assertEqual(nato.faction, "nato")
+        self.assertEqual(ru.faction, "ru")
+
     def test_reject_three_value_pairs(self):
         with self.assertRaises(ValueError):
-            compute_distance_bearing_xy((0, 0, 10), (3000, 0))
+            compute_distance_bearing_xy((0, 0, 10), (3000, 0))  # type: ignore[arg-type]
         with self.assertRaises(ValueError):
-            compute_distance_bearing_xy((0, 0), (3000, 0, 20))
+            compute_distance_bearing_xy((0, 0), (3000, 0, 20))  # type: ignore[arg-type]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds support for RU/Warsaw 6000-mil system in addition to NATO 6400.\n- CLI: --faction and --set-faction, persisted in config.\n- Web UI: faction dropdown persisted in localStorage.\n- Tests added and all pass locally.\n\nThis branch implements user-requested feature to select faction and persist selection for CLI and web UI.